### PR TITLE
Install libtool with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ docker-image: rootfs
 docker-image-test: docker-image
 	# FIXME: /etc/mtab is hidden by docker so the stricter -Qkk fails
 	docker run --rm $(DOCKER_ORGANIZATION)/$(DOCKER_IMAGE) sh -c "/usr/bin/pacman -Sy && /usr/bin/pacman -Qqk"
-	docker run --rm $(DOCKER_ORGANIZATION)/$(DOCKER_IMAGE) sh -c "/usr/bin/pacman -Syu --noconfirm docker && docker -v"
+	docker run --rm $(DOCKER_ORGANIZATION)/$(DOCKER_IMAGE) sh -c "/usr/bin/pacman -Syu --noconfirm libtool docker && docker -v"
 	# Ensure that the image does not include a private key
 	! docker run --rm $(DOCKER_ORGANIZATION)/$(DOCKER_IMAGE) pacman-key --lsign-key pierre@archlinux.de
 
 ci-test:
 	docker run --rm --privileged --tmpfs=/tmp:exec --tmpfs=/run/shm -v /run/docker.sock:/run/docker.sock \
 		-v $(PWD):/app -w /app $(DOCKER_ORGANIZATION)/$(DOCKER_IMAGE) \
-		sh -c 'pacman -Syu --noconfirm make devtools docker && make docker-image-test'
+		sh -c 'pacman -Syu --noconfirm make devtools libtool docker && make docker-image-test'
 
 docker-push: docker-image-test
 	docker login -u $(DOCKER_USER)


### PR DESCRIPTION
Installs `libtool` along with docker since docker depends on it at runtime:

```
docker: error while loading shared libraries: libltdl.so.7: cannot open shared object file: No such file or directory
```

`libtool` is not pulled in by docker since it's in `core`.